### PR TITLE
Fix typo in version reference for starknet-devnet installation instructions

### DIFF
--- a/docs/quick-start/installation.mdx
+++ b/docs/quick-start/installation.mdx
@@ -75,7 +75,7 @@ To accomplish this, first check your local starknet-devnet version:
 starknet-devnet --version
 ```
 
-If your local starknet-devnet version is not `0.0.4`, you need to install it.
+If your local starknet-devnet version is not `0.2.0`, you need to install it.
 
 ```sh
 cargo install starknet-devnet --version 0.2.0


### PR DESCRIPTION
This PR corrects a typo in the documentation where the starknet-devnet version 0.0.4 was mentioned incorrectly. It now reflects the correct version 0.2.0.

Fixes #57 

