### PR TITLE
fix(docs): correct spelling of 'testnet' and update deploy script path

### DIFF
--- a/docs/quick-start/environment.mdx
+++ b/docs/quick-start/environment.mdx
@@ -27,9 +27,9 @@ In the second terminal, deploy the test contract:
 yarn deploy --network {NETWORK_NAME} // when NETWORK_NAME is not specified, it defaults to "devnet"
 ```
 
-**Note:** To use sepolia tesnet, you have to set {NETWORK_NAME} to `sepolia`.
+**Note:** To use sepolia testnet, you have to set {NETWORK_NAME} to `sepolia`.
 
-This command deploys a sample smart contract to the local network. The contract is located in `packages/snfoundry/contracts/src` and can be modified to suit your needs. The `yarn deploy` command uses the deploy script located in `packages/snfoundry/scripts-js/deploy.js` to deploy the contract to the network. You can also customize the deploy script.
+This command deploys a sample smart contract to the local network. The contract is located in `packages/snfoundry/contracts/src` and can be modified to suit your needs. The `yarn deploy` command uses the deploy script located in `packages/snfoundry/scripts-ts/deploy.ts` to deploy the contract to the network. You can also customize the deploy script.
 
 The command also will create a file called `packages/nextjs/contracts/deployedContracts.ts` within the Next.js App, which would be the ABI source-of-truth for the Scaffold Hooks. This enables autocomplete to be activated when you are building the Next.js front-end of the application.
 


### PR DESCRIPTION
# Task name here

Fixes spelling of 'testnet' and update deploy script path

## Types of change

- [x] Bug
- [ ] Enhancement

## Comments (optional)
