### PR TITLE
feat: optional algolia

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
-APP_ID=
-API_KEY=
-INDEX_NAME=
+ALGOLIA_SEARCH_ENABLED=false
+
+# if ALGOLIA_SEARCH_ENABLED is true, you need to fill in these environment variables
+ALGOLIA_APP_ID=
+ALGOLIA_API_KEY=
+ALGOLIA_INDEX_NAME=

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .docusaurus
 build
 .idea
+.env

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ npm run start
 
 The repository will disable Algolia search by default. you can enable Algolia search by setting `ALGOLIA_SEARCH_ENABLED` environment variable to `true`, provided you have the other required environment variables.
 
+Note that you might need to restart the app after you update the environment variables.
+
 ## Contribution Guidelines
 
 Thank you for your interest in contributing to improve the documentation!

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ npm install
 npm run start
 ```
 
+### Using the Algolia Search
+
+The repository will disable Algolia search by default. you can enable Algolia search by setting `ALGOLIA_SEARCH_ENABLED` environment variable to `true`, provided you have the other required environment variables.
+
 ## Contribution Guidelines
 
 Thank you for your interest in contributing to improve the documentation!

--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -27,10 +27,10 @@ By default `yarn deploy` will deploy contract to the local network. You can chan
 Run the command below to deploy the smart contract to the target network. Make sure to have some funds in your deployer account to pay for the transaction.
 
 ```
-yarn deploy --network network_name
+yarn deploy --network <NETWORK_NAME>
 ```
 
-eg: `yarn deploy --network sepolia`
+e.g. `yarn deploy --network sepolia`
 
 ## Configuration of Third-Party Services for Production-Grade Apps.
 
@@ -41,5 +41,5 @@ For production-grade applications, it's recommended to obtain your own API keys 
 - `RPC_URL_SEPOLIA` variable in `packages/snfoundry/.env` and `packages/nextjs/.env.local`. You can create API keys from the [Alchemy dashboard](https://dashboard.alchemy.com/).
 
 :::tip Hint
-It's recommended to store envs for nextjs in Vercel/system env config for live apps and use .env.local for local testing.
+It's recommended to store environment variables for nextjs in vercel/system env config for live apps and use `.env.local` for local testing.
 :::tip Hint

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -132,20 +132,24 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
-      algolia: {
-        appId: process.env.APP_ID,
-        apiKey: process.env.API_KEY,
-        indexName: process.env.INDEX_NAME,
-        contextualSearch: true,
-        externalUrlRegex: "external\\.com|domain\\.com",
-        replaceSearchResultPathname: {
-          from: "/docs/",
-          to: "/",
-        },
-        searchParameters: {},
-        searchPagePath: "search",
-        insights: false,
-      },
+      ...((process.env.ALGOLIA_SEARCH_ENABLED || "false") === "true"
+        ? {
+            algolia: {
+              appId: process.env.ALGOLIA_APP_ID,
+              apiKey: process.env.ALGOLIA_API_KEY,
+              indexName: process.env.ALGOLIA_INDEX_NAME,
+              contextualSearch: true,
+              externalUrlRegex: "external\\.com|domain\\.com",
+              replaceSearchResultPathname: {
+                from: "/docs/",
+                to: "/",
+              },
+              searchParameters: {},
+              searchPagePath: "search",
+              insights: false,
+            },
+          }
+        : {}),
     }),
 };
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "format": "npx prettier --write '**/*.{js,jsx,md,mdx,json,css}'",
-    "format-check": "npx prettier --check '**/*.{js,jsx,md,mdx,json,css}'"
+    "format-check": "npx prettier --check '**/*.{js,jsx,md,mdx,json,css}'",
+    "postinstall": "cp -n .env.example .env"
   },
   "dependencies": {
     "@docusaurus/core": "2.4.0",


### PR DESCRIPTION
# Optional Algolia

Currently the absence of algolia API keys might block people from developing, this PR provide changes where algolia is optional (controlled via env). This PR will also add a postinstall script that automatically sets up the env file.

## Types of change

- [ ] Bug
- [X] Enhancement

## Comments (optional)

- Might need @jrcarlos2000 help to update the deployment on the server in regards to the environment variable
