### PR TITLE
Add a link menu point to upgrade helper

### DIFF
--- a/docs/upgrade-helper/_category_.json
+++ b/docs/upgrade-helper/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "🔗 Upgrade Scaffold",
+  "position": 9,
+  "link": {
+    "type": "doc",
+    "id": "upgrade-helper/external-link"
+  },
+  "className": "external-link-item"
+}

--- a/docs/upgrade-helper/external-link.md
+++ b/docs/upgrade-helper/external-link.md
@@ -1,0 +1,8 @@
+---
+title: 🔗 Upgrade Scaffold
+hide_table_of_contents: true
+---
+
+import ExternalRedirect from '@site/src/components/ExternalRedirect';
+
+<ExternalRedirect to="https://scaffold-stark.github.io/scaffold-upgrade-helper/" />

--- a/src/components/ExternalRedirect.jsx
+++ b/src/components/ExternalRedirect.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from "react";
+import { useHistory } from "@docusaurus/router";
+
+export default function ExternalRedirect({ to }) {
+  const history = useHistory();
+
+  useEffect(() => {
+    const newWindow = window.open(to, "_blank");
+    if (newWindow) {
+      history.push("/");
+    }
+  }, []);
+
+  return (
+    <div>
+      <p>
+        Opening external link... If nothing happens,{" "}
+        <a href={to} target="_blank">
+          click here
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -32,3 +32,12 @@ h1 {
 details[open] {
   min-height: 50px;
 }
+
+.external-link-item a::after {
+  content: "↗";
+  margin-left: 5px;
+}
+
+.external-link-item a {
+  target: "_blank";
+}


### PR DESCRIPTION
# Add a link menu point to upgrade helper

Create a [github page](https://scaffold-stark.github.io/scaffold-upgrade-helper) to help user upgrade scaffold, and add the link in doc

## Types of change

- [ ] Bug
- [x] Enhancement

